### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,6 @@ test:
 about:
   home: https://github.com/anthropics/anthropic-sdk-python
   license: MIT
-  license_file: MIT
   license_file: LICENSE
   summary: 'Library for accessing the anthropic API'
   doc_url: https://console.anthropic.com/docs


### PR DESCRIPTION
Weird that the linter didn't catch this. This is why the feedstock wasn't being updated automatically.